### PR TITLE
Eliminate possible side-effects

### DIFF
--- a/HotelBooking.UnitTests/Services/BookingManagerTests.cs
+++ b/HotelBooking.UnitTests/Services/BookingManagerTests.cs
@@ -1,7 +1,5 @@
 using System;
 using FluentAssertions;
-using FluentAssertions.Extensions;
-using FsCheck;
 using FsCheck.Xunit;
 using HotelBooking.Core;
 using HotelBooking.UnitTests.Fakes;
@@ -22,11 +20,11 @@ namespace HotelBooking.UnitTests.Services
                 return new BookingManager(bookingRepository, roomRepository);
             }
         }
-      
+
         [Fact]
         public void FindAvailableRoom_StartDateNotInTheFuture_ThrowsArgumentException()
         {
-            DateTime date = DateTime.Today;
+            var date = DateTime.Today;
             Assert.Throws<ArgumentException>(() => BookingManager.FindAvailableRoom(date, date));
         }
 
@@ -34,9 +32,9 @@ namespace HotelBooking.UnitTests.Services
         public void FindAvailableRoom_RoomAvailable_RoomIdNotMinusOne()
         {
             // Arrange
-            DateTime date = DateTime.Today.AddDays(1);
+            var date = DateTime.Today.AddDays(1);
             // Act
-            int roomId = BookingManager.FindAvailableRoom(date, date);
+            var roomId = BookingManager.FindAvailableRoom(date, date);
             // Assert
             Assert.NotEqual(-1, roomId);
         }
@@ -44,7 +42,8 @@ namespace HotelBooking.UnitTests.Services
         [Fact]
         public void GetFullyOccupiedDates_InvalidDates()
         {
-            Assert.Throws<ArgumentException>(() => BookingManager.GetFullyOccupiedDates(DateTime.MaxValue, DateTime.MinValue));
+            Assert.Throws<ArgumentException>(() =>
+                BookingManager.GetFullyOccupiedDates(DateTime.MaxValue, DateTime.MinValue));
         }
 
         [Fact(Skip = "I don't know how to fix this")]
@@ -61,20 +60,15 @@ namespace HotelBooking.UnitTests.Services
         }
 
         [Property]
-        public void GetFullyOccupiedDates(DateTime start,DateTime end)
+        public void GetFullyOccupiedDates(DateTime start, DateTime end)
         {
             if (start > end)
-            {
                 Assert.Throws<ArgumentException>(() => BookingManager.GetFullyOccupiedDates(start, end));
-            }
             else
-            {
                 BookingManager.GetFullyOccupiedDates(start, end).Should()
                     .NotBeNull().And
                     .NotContainNulls().And
                     .HaveCountLessOrEqualTo(11);
-            }
         }
-
     }
 }

--- a/HotelBooking.UnitTests/Services/BookingManagerTests.cs
+++ b/HotelBooking.UnitTests/Services/BookingManagerTests.cs
@@ -11,21 +11,23 @@ namespace HotelBooking.UnitTests.Services
 {
     public class BookingManagerTests
     {
-        private IBookingManager bookingManager;
-
-        public BookingManagerTests(){
-            DateTime start = DateTime.Today.AddDays(10);
-            DateTime end = DateTime.Today.AddDays(20);
-            IRepository<Booking> bookingRepository = new FakeBookingRepository(start, end);
-            IRepository<Room> roomRepository = new FakeRoomRepository();
-            bookingManager = new BookingManager(bookingRepository, roomRepository);
+        private static IBookingManager BookingManager
+        {
+            get
+            {
+                var start = DateTime.Today.AddDays(10);
+                var end = DateTime.Today.AddDays(20);
+                IRepository<Booking> bookingRepository = new FakeBookingRepository(start, end);
+                IRepository<Room> roomRepository = new FakeRoomRepository();
+                return new BookingManager(bookingRepository, roomRepository);
+            }
         }
-
+      
         [Fact]
         public void FindAvailableRoom_StartDateNotInTheFuture_ThrowsArgumentException()
         {
             DateTime date = DateTime.Today;
-            Assert.Throws<ArgumentException>(() => bookingManager.FindAvailableRoom(date, date));
+            Assert.Throws<ArgumentException>(() => BookingManager.FindAvailableRoom(date, date));
         }
 
         [Fact]
@@ -34,7 +36,7 @@ namespace HotelBooking.UnitTests.Services
             // Arrange
             DateTime date = DateTime.Today.AddDays(1);
             // Act
-            int roomId = bookingManager.FindAvailableRoom(date, date);
+            int roomId = BookingManager.FindAvailableRoom(date, date);
             // Assert
             Assert.NotEqual(-1, roomId);
         }
@@ -42,20 +44,20 @@ namespace HotelBooking.UnitTests.Services
         [Fact]
         public void GetFullyOccupiedDates_InvalidDates()
         {
-            Assert.Throws<ArgumentException>(() => bookingManager.GetFullyOccupiedDates(DateTime.MaxValue, DateTime.MinValue));
+            Assert.Throws<ArgumentException>(() => BookingManager.GetFullyOccupiedDates(DateTime.MaxValue, DateTime.MinValue));
         }
 
         [Fact(Skip = "I don't know how to fix this")]
         public void GetFullyOccupiedDates_All()
         {
-            var dates = bookingManager.GetFullyOccupiedDates(DateTime.MinValue, DateTime.MaxValue);
+            var dates = BookingManager.GetFullyOccupiedDates(DateTime.MinValue, DateTime.MaxValue);
             dates.Should().HaveCount(10);
         }
 
         [Fact]
         public void FindAvailableRoom_StartDateOk_EndDateConflict()
         {
-            bookingManager.FindAvailableRoom(DateTime.Today.AddDays(5), DateTime.Today.AddDays(15)).Should().Be(-1);
+            BookingManager.FindAvailableRoom(DateTime.Today.AddDays(5), DateTime.Today.AddDays(15)).Should().Be(-1);
         }
 
         [Property]
@@ -63,11 +65,11 @@ namespace HotelBooking.UnitTests.Services
         {
             if (start > end)
             {
-                Assert.Throws<ArgumentException>(() => bookingManager.GetFullyOccupiedDates(start, end));
+                Assert.Throws<ArgumentException>(() => BookingManager.GetFullyOccupiedDates(start, end));
             }
             else
             {
-                bookingManager.GetFullyOccupiedDates(start, end).Should()
+                BookingManager.GetFullyOccupiedDates(start, end).Should()
                     .NotBeNull().And
                     .NotContainNulls().And
                     .HaveCountLessOrEqualTo(11);


### PR DESCRIPTION
Before, one BookingManager was shared between all the tests
Now, one is created for each test
That way, if they ran one after another, or in parallel, they can't influence each other